### PR TITLE
Pushing the Map a bit further.

### DIFF
--- a/flighty.xcodeproj/project.pbxproj
+++ b/flighty.xcodeproj/project.pbxproj
@@ -99,11 +99,11 @@
 		83D0D3882BC969C500D0D6AB /* flighty */ = {
 			isa = PBXGroup;
 			children = (
+				83D0D3892BC969C500D0D6AB /* flightyApp.swift */,
+				83D0D38B2BC969C500D0D6AB /* ContentView.swift */,
 				835E2D6F2BD7092000064605 /* Models */,
 				835E2D6C2BD5D6C100064605 /* Views */,
 				835E2D742BD709F300064605 /* Extensions & Utilities */,
-				83D0D3892BC969C500D0D6AB /* flightyApp.swift */,
-				83D0D38B2BC969C500D0D6AB /* ContentView.swift */,
 				83D0D38D2BC969C600D0D6AB /* Assets.xcassets */,
 				83D0D38F2BC969C600D0D6AB /* Preview Content */,
 			);

--- a/flighty/Assets.xcassets/flightyBlue.colorset/Contents.json
+++ b/flighty/Assets.xcassets/flightyBlue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "251",
+          "green" : "121",
+          "red" : "69"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "251",
+          "green" : "121",
+          "red" : "69"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/flighty/Assets.xcassets/flightyLightBlue.colorset/Contents.json
+++ b/flighty/Assets.xcassets/flightyLightBlue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "254",
+          "green" : "149",
+          "red" : "94"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "254",
+          "green" : "149",
+          "red" : "94"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/flighty/Assets.xcassets/flightyPathPrimary.colorset/Contents.json
+++ b/flighty/Assets.xcassets/flightyPathPrimary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "253",
+          "green" : "194",
+          "red" : "165"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "253",
+          "green" : "194",
+          "red" : "165"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/flighty/Assets.xcassets/flightyPathSecondary.colorset/Contents.json
+++ b/flighty/Assets.xcassets/flightyPathSecondary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "240",
+          "green" : "148",
+          "red" : "107"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "240",
+          "green" : "148",
+          "red" : "107"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/flighty/ContentView.swift
+++ b/flighty/ContentView.swift
@@ -12,11 +12,53 @@ struct ContentView: View {
     @StateObject var uiModel = UIModel()
     @State private var sheetPresented: Bool = true
     @State private var referenceOpacity = 0.0
+    @State private var camera: MapCameraPosition = .camera(MapCamera(centerCoordinate: CLLocationCoordinate2D(latitude: 35.44722362595532, longitude: -86.03197387024086), distance: 5_000_000))
+
+    let locations: [AirportAnnotation] = [
+        AirportAnnotation(code: "ATL", name: "Atlanta", coordinate: .atl),
+        AirportAnnotation(code: "ORD", name: "Chicago", coordinate: .ord)
+    ]
+
+    let flightRoute: [CLLocationCoordinate2D] = [.atl, .midPoint, .ord]
 
     var body: some View {
         ZStack(alignment: Alignment(horizontal: .trailing, vertical: .top)) {
-            Map {
+            Map(position: $camera) {
+                ForEach(locations) { location in
+                    Annotation("\(location.name)", coordinate: location.coordinate, anchor: .leading) {
+                        HStack(spacing: 3) {
+                            Circle()
+                                .fill(.flightyBlue)
+                                .stroke(.white, lineWidth: 2)
+                                .frame(maxWidth: 15)
 
+                            HStack(spacing: 0) {
+                                Text(location.code)
+                                    .font(.system(size: 10).weight(.semibold))
+                                    .foregroundStyle(.white)
+                                    .padding(.leading, 4)
+                                    .padding(.trailing, 3)
+                                    .frame(maxHeight: .infinity, alignment: .center)
+                                    .background(.flightyBlue)
+
+                                Text(location.name)
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.white)
+                                    .padding(.vertical, 3)
+                                    .padding(.leading, 3)
+                                    .padding(.trailing, 4)
+                                    .background(.flightyLightBlue)
+
+                            }
+                            .clipShape(RoundedRectangle(cornerRadius: 5.0))
+                            .fixedSize()
+                        }
+                        .offset(x: -4)
+                    }
+
+                    MapPolyline(coordinates: flightRoute)
+                        .stroke(.blue, lineWidth: 3)
+                }
             }
             .ignoresSafeArea()
 
@@ -38,6 +80,9 @@ struct ContentView: View {
             .sheet(isPresented: $sheetPresented) {
                 FlightDetails(sheetPresented: $sheetPresented)
                     .presentationDetents([.height(200), .medium, .fraction(0.95)], selection: $uiModel.selectedDetent)
+                    .presentationBackgroundInteraction(
+                        .enabled(upThrough: .medium)
+                    )
                     .presentationDragIndicator(.hidden)
                     .presentationCornerRadius(21)
                     .interactiveDismissDisabled()
@@ -73,4 +118,18 @@ struct ViewOffsetKey: PreferenceKey {
     static func reduce(value: inout Value, nextValue: () -> Value) {
         value += nextValue()
     }
+}
+
+struct AirportAnnotation: Identifiable {
+    let id = UUID()
+    let code: String
+    let name: String
+    let coordinate: CLLocationCoordinate2D
+}
+
+extension CLLocationCoordinate2D {
+    static let atl = CLLocationCoordinate2D(latitude: 33.640411, longitude: -84.419853)
+    static let ord = CLLocationCoordinate2D(latitude: 41.978611, longitude: -87.904724)
+    static let midPoint = CLLocationCoordinate2D(latitude: 39.06903755242377, longitude: -86.79896452319443)
+    static let overLake = CLLocationCoordinate2D(latitude: 42.03559217412583, longitude: -86.82568547736001)
 }

--- a/flighty/ContentView.swift
+++ b/flighty/ContentView.swift
@@ -30,7 +30,7 @@ struct ContentView: View {
                             Circle()
                                 .fill(.flightyBlue)
                                 .stroke(.white, lineWidth: 2)
-                                .frame(maxWidth: 15)
+                                .frame(height: 12)
 
                             HStack(spacing: 0) {
                                 Text(location.code)
@@ -48,16 +48,17 @@ struct ContentView: View {
                                     .padding(.leading, 3)
                                     .padding(.trailing, 4)
                                     .background(.flightyLightBlue)
-
                             }
                             .clipShape(RoundedRectangle(cornerRadius: 5.0))
                             .fixedSize()
                         }
-                        .offset(x: -4)
+                        .offset(x: -5)
                     }
 
                     MapPolyline(coordinates: flightRoute)
-                        .stroke(.blue, lineWidth: 3)
+                        .stroke(.flightyPathSecondary, lineWidth: 5)
+                    MapPolyline(coordinates: flightRoute)
+                        .stroke(.flightyPathPrimary, lineWidth: 2)
                 }
             }
             .ignoresSafeArea()

--- a/flighty/Models/UIModel.swift
+++ b/flighty/Models/UIModel.swift
@@ -9,5 +9,5 @@ import SwiftUI
 
 // Simple model for synchronizing the state of the UI across the app.
 class UIModel: ObservableObject {
-    @Published var selectedDetent: PresentationDetent = .fraction(0.95)
+    @Published var selectedDetent: PresentationDetent = .height(200)
 }

--- a/flighty/Views/FlightDetails.swift
+++ b/flighty/Views/FlightDetails.swift
@@ -10,13 +10,13 @@ import SwiftUI
 struct FlightDetails: View {
     @EnvironmentObject var uiModel: UIModel
     @State private var previousScrollOffset: CGFloat = 0
+    @State private var closeOpacity: Double = 0
     @Binding var sheetPresented: Bool
     let minimumOffset: CGFloat = 5
 
     var body: some View {
         ScrollView {
             LazyVStack(spacing: 10, pinnedViews: [.sectionHeaders]) {
-                // Scrolling horizontal sub-actions.
                 Section {
                     HorizontalActions()
 
@@ -80,6 +80,7 @@ struct FlightDetails: View {
                     .opacity(0.5)
                     .frame(maxWidth: .infinity, alignment: .trailing)
                     .offset(x: 5, y: -15)
+                    .opacity(closeOpacity)
             }
             .buttonStyle(.plain)
         }
@@ -92,9 +93,20 @@ struct FlightDetails: View {
                 .frame(width: nil, height: 0.5, alignment: .top)
                 .foregroundColor(.lightGrey.opacity((previousScrollOffset - minimumOffset) / Double(10))),
         alignment: .bottom)
+        .onChange(of: uiModel.selectedDetent) {
+            withAnimation(.easeOut(duration: 0.2)) {
+                closeOpacity = uiModel.selectedDetent == .height(200) ? 0 : 1
+            }
+        }
     }
 }
 
 #Preview {
     FlightDetails(sheetPresented: .constant(true))
+}
+
+extension View {
+    func hidden(_ shouldHide: Bool) -> some View {
+        opacity(shouldHide ? 0 : 1)
+    }
 }


### PR DESCRIPTION
* Adds an `AirportAnnotation` struct for encapsulating details for each map annotation.
* Extends `CLLocationCoordinate2D` with some handy static coordinates.
* Updates the default `PresentationDetent` to be in its smallest/"closed" state.
* Include some logic to show/hide the close button based on the state of the presented Flight Details sheet.
* Builds out the basics of the Map, including annotations for departure and arrival airports and mock flight path.
* Makes the Map interactive while the `sheet` is presented using `.presentationBackgroundInteraction().`